### PR TITLE
Fixed GitHub workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,11 +3,11 @@
 
 name: Go
 
-on: push
-  # push:
-  #   branches: [ "main" ]
-  # pull_request:
-  #   branches: [ "main" ]
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 jobs:
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,11 +3,11 @@
 
 name: Go
 
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: push
+  # push:
+  #   branches: [ "main" ]
+  # pull_request:
+  #   branches: [ "main" ]
 
 jobs:
 
@@ -21,13 +21,8 @@ jobs:
       with:
         go-version: '1.22.6'
 
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-    
-    - name: Install protoc-gen-go
-      run: |
-        go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-        go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+    - name: Install buf
+      uses: bufbuild/buf-action@v1
 
     - name: Compile protocol buffers
       run: make proto

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.22.6'
+        go-version: '1.23.2'
 
     - name: Install buf
       uses: bufbuild/buf-action@v1


### PR DESCRIPTION
## Problem

The `make proto` recipe was failing because it now uses the `buf`  tool instead of protoc and go GRPC source code. The reason for the failure was that the Workflow doesn't come with the tool by default and threw an error:

```
mkdir -p proto/gen
cd proto/gen; go mod init github.com/AranGarcia/droop/proto/gen
go: creating new go.mod: module github.com/AranGarcia/droop/proto/gen
buf generate
make: buf: No such file or directory
make: *** [Makefile:2: proto] Error 12[7](https://github.com/AranGarcia/droop/actions/runs/11218368804/job/31181988179#step:6:8)
Error: Process completed with exit code 2.
```

## Changes introduced

- Used [buf](https://buf.build/docs/ci-cd/github-actions) as a GitHub Action
- Bumped Go version to `1.23.2`